### PR TITLE
Add option to always show latest Tweets

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Customization currently available in Chrome and Firefox! ⚙️
 
 - Select preferred width of Twitter feed sections
 - Anchor navigation to top
+- Always show latest Tweets
 - Minimize borders between tweets, in explore, and in notifications
 - Hide the bottom right Tweet button
 - Hide retweet and/or like numbers

--- a/chrome/applyOptions.js
+++ b/chrome/applyOptions.js
@@ -5,10 +5,19 @@ function addStyles(css) {
   head.appendChild(style);
 }
 
+function showLatestTweets(){
+  const button = document.querySelector("div[aria-label='Top Tweets on']");
+  if(button){
+    button.click();
+    document.querySelector("div[role='menuitem'][tabindex='0']").click();
+  }
+}
+
 chrome.storage.sync.get(
   {
     feedWidth: "600",
     topNavigation: false,
+    showLatest: false,
     noTweetButton: false,
     showMessageDrawer: false,
     feedBorders: false,
@@ -52,6 +61,17 @@ chrome.storage.sync.get(
         padding-top: 6px;
       }
       `);
+    }
+
+    if (items.showLatest === true) {
+ 
+      showLatestTweets();
+
+      //Set onclick as well in case they nagivate to a non-home page when first loading the site
+      document.querySelector("a[aria-label='Home']").onclick = () => {
+        setTimeout(showLatestTweets,50);
+      };
+
     }
 
     if (items.noTweetButton === true) {

--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -2,7 +2,7 @@
   "name": "Minimal Twitter",
   "short_name": "MinTwitter",
   "description": "Extends Twitter UI functionality by adding CSS to make the UI cleaner. No big labels, cluttered elements, and distracting text.",
-  "version": "2.72",
+  "version": "2.73",
   "manifest_version": 2,
   "permissions": [
     "storage"

--- a/chrome/options.html
+++ b/chrome/options.html
@@ -543,6 +543,12 @@
     </p>
     <p>
       <label>
+        <input type="checkbox" id="latest" />
+        <span>Always show latest Tweets</span>
+      </label>
+    </p>
+    <p>
+      <label>
         <input type="checkbox" id="feed-borders" />
         <span>Feed borders</span>
       </label>

--- a/chrome/options.js
+++ b/chrome/options.js
@@ -2,6 +2,7 @@
 function save_options() {
   var feedWidth = document.getElementById("feed-width").value;
   var topNavigation = document.getElementById("top-navigation").checked;
+  var showLatest = document.getElementById("latest").checked;
   var noTweetButton = document.getElementById("tweet").checked;
   var showMessageDrawer = document.getElementById("message").checked;
   var feedBorders = document.getElementById("feed-borders").checked;
@@ -16,6 +17,7 @@ function save_options() {
     {
       feedWidth: feedWidth,
       topNavigation: topNavigation,
+      showLatest: showLatest,
       noTweetButton: noTweetButton,
       showMessageDrawer: showMessageDrawer,
       feedBorders: feedBorders,
@@ -45,6 +47,7 @@ function restore_options() {
     {
       feedWidth: "600",
       topNavigation: false,
+      showLatest: false,
       noTweetButton: false,
       showMessageDrawer: false,
       feedBorders: false,
@@ -58,6 +61,7 @@ function restore_options() {
     },
     function (items) {
       document.getElementById("feed-width").value = items.feedWidth;
+      document.getElementById("latest").checked = items.showLatest;
       document.getElementById("top-navigation").checked = items.topNavigation;
       document.getElementById("tweet").checked = items.noTweetButton;
       document.getElementById("message").checked = items.showMessageDrawer;

--- a/firefox/applyOptions.js
+++ b/firefox/applyOptions.js
@@ -5,10 +5,19 @@ function addStyles(css) {
   head.appendChild(style);
 }
 
+function showLatestTweets(){
+  const button = document.querySelector("div[aria-label='Top Tweets on']");
+  if(button){
+    button.click();
+    document.querySelector("div[role='menuitem'][tabindex='0']").click();
+  }
+}
+
 chrome.storage.sync.get(
   {
     feedWidth: "600",
     topNavigation: false,
+    showLatest: false,
     noTweetButton: false,
     showMessageDrawer: false,
     feedBorders: false,
@@ -52,6 +61,17 @@ chrome.storage.sync.get(
         padding-top: 6px;
       }
       `);
+    }
+
+    if (items.showLatest === true) {
+ 
+      showLatestTweets();
+
+      //Set onclick as well in case they nagivate to a non-home page when first loading the site
+      document.querySelector("a[aria-label='Home']").onclick = () => {
+        setTimeout(showLatestTweets,50);
+      };
+
     }
 
     if (items.noTweetButton === true) {

--- a/firefox/manifest.json
+++ b/firefox/manifest.json
@@ -2,7 +2,7 @@
   "name": "Minimal Twitter",
   "short_name": "MinTwitter",
   "description": "Extends Twitter UI functionality by adding CSS to make the UI cleaner. No big labels, cluttered elements, and distracting text.",
-  "version": "2.72",
+  "version": "2.73",
   "manifest_version": 2,
   "permissions": [
     "activeTab",

--- a/firefox/options.html
+++ b/firefox/options.html
@@ -543,6 +543,12 @@
     </p>
     <p>
       <label>
+        <input type="checkbox" id="latest" />
+        <span>Always show latest Tweets</span>
+      </label>
+    </p>
+    <p>
+      <label>
         <input type="checkbox" id="feed-borders" />
         <span>Feed borders</span>
       </label>

--- a/firefox/options.js
+++ b/firefox/options.js
@@ -2,6 +2,7 @@
 function save_options() {
   var feedWidth = document.getElementById("feed-width").value;
   var topNavigation = document.getElementById("top-navigation").checked;
+  var showLatest = document.getElementById("latest").checked;
   var noTweetButton = document.getElementById("tweet").checked;
   var showMessageDrawer = document.getElementById("message").checked;
   var feedBorders = document.getElementById("feed-borders").checked;
@@ -16,6 +17,7 @@ function save_options() {
     {
       feedWidth: feedWidth,
       topNavigation: topNavigation,
+      showLatest: showLatest,
       noTweetButton: noTweetButton,
       showMessageDrawer: showMessageDrawer,
       feedBorders: feedBorders,
@@ -45,6 +47,7 @@ function restore_options() {
     {
       feedWidth: "600",
       topNavigation: false,
+      showLatest: false,
       noTweetButton: false,
       showMessageDrawer: false,
       feedBorders: false,
@@ -58,6 +61,7 @@ function restore_options() {
     },
     function (items) {
       document.getElementById("feed-width").value = items.feedWidth;
+      document.getElementById("latest").checked = items.showLatest;
       document.getElementById("top-navigation").checked = items.topNavigation;
       document.getElementById("tweet").checked = items.noTweetButton;
       document.getElementById("message").checked = items.showMessageDrawer;


### PR DESCRIPTION
Twitter allows users to choose whether their feed displays "top Tweets" first ("Home" mode) or the latest Tweets first ("Latest Tweets" mode). In "Home" mode, users will occasionally see Tweets in their feed from accounts they do not follow because an account they do follow replied or liked the Tweet. If the user changes to "Latest Tweets" mode, Twitter will force them back to "Home" mode after "a while." Some users, myself included, find this behavior undesirable for a multitude of reasons. This PR adds an option to ensure that the feed is always in "Latest Tweets" mode.
 
![image](https://user-images.githubusercontent.com/19439373/104976924-50479100-59cc-11eb-88f0-de47664c5604.png)

(Tested on Chromium Version 87.0.4280.141 and Firefox 84.0.2)

(I'm new to contributing to GitHub projects, and you wrote in the read me that users can clone / fork as wanted. I was starting to work on something similar myself, but I remembered your add on. I thought I'd open a PR as an option to add this feature to this repo.) @thomaswang 