### PR TITLE
chrome: add option to hide profile Who To Follow

### DIFF
--- a/chrome/applyOptions.js
+++ b/chrome/applyOptions.js
@@ -41,6 +41,7 @@ chrome.storage.sync.get(
     noNotificationsButton: false,
     noBookmarksButton: false,
     noListsButton: false,
+    noWhoToFollow: false,
   },
   function (items) {
     if (items.feedWidth === "700") {
@@ -157,6 +158,20 @@ chrome.storage.sync.get(
       addStyles(`header > div > div > div > div > div:nth-child(2) > nav > a:nth-child(6) {
         display: none !important;
       }`);
+    }
+
+    if (items.noWhoToFollow === true) {
+      addStyles(`
+        [aria-label^="Timeline"][aria-label$="s Tweets"] h2 {
+          display: none !important;
+        }
+        [aria-label^="Timeline"][aria-label$="s Tweets"] [data-testid="UserCell"] {
+          display: none !important;
+        }
+        [aria-label^="Timeline"][aria-label$="s Tweets"] [href^="/i/connect_people?user_id="] {
+          display: none !important;
+        }
+      `);
     }
   }
 );

--- a/chrome/options.html
+++ b/chrome/options.html
@@ -575,6 +575,12 @@
             <span>Show bottom right Message Drawer</span>
           </label>
         </p>
+        <p>
+          <label>
+            <input type="checkbox" id="who-to-follow" />
+            <span>Remove profile Who To Follow</span>
+          </label>
+        </p>
       </div>
       <div style="margin-left: 1rem">
         <p>

--- a/chrome/options.js
+++ b/chrome/options.js
@@ -13,6 +13,7 @@ function save_options() {
   var noNotificationsButton = document.getElementById("notifications").checked;
   var noBookmarksButton = document.getElementById("bookmarks").checked;
   var noListsButton = document.getElementById("lists").checked;
+  var noWhoToFollow = document.getElementById("who-to-follow").checked;
   chrome.storage.sync.set(
     {
       feedWidth: feedWidth,
@@ -28,6 +29,7 @@ function save_options() {
       noNotificationsButton: noNotificationsButton,
       noBookmarksButton: noBookmarksButton,
       noListsButton: noListsButton,
+      noWhoToFollow: noWhoToFollow,
     },
     function () {
       // Update status to let user know options were saved.
@@ -58,6 +60,7 @@ function restore_options() {
       noNotificationsButton: false,
       noBookmarksButton: false,
       noListsButton: false,
+      noWhoToFollow: false,
     },
     function (items) {
       document.getElementById("feed-width").value = items.feedWidth;
@@ -74,6 +77,7 @@ function restore_options() {
         items.noNotificationsButton;
       document.getElementById("bookmarks").checked = items.noBookmarksButton;
       document.getElementById("lists").checked = items.noListsButton;
+      document.getElementById("who-to-follow").checked = items.noWhoToFollow;
     }
   );
 }


### PR DESCRIPTION
This PR adds the ability to turn off Who To Follow sections on Profiles (Tweets and Tweets & replies two tabs).

Before:
![who-to-follow-before](https://user-images.githubusercontent.com/37485853/109090981-c5dc0680-76c8-11eb-956e-a1f349ebc4b5.png)

After:
![who-to-follow-after](https://user-images.githubusercontent.com/37485853/109090998-cbd1e780-76c8-11eb-9d85-02dc1f38b023.png)

I didn't see a parent selector with a reliable name to remove the whole section (h2 Who to follow text, 3 profiles, Show more text). For that reason, the 5 elements are removed.

This change makes the options appear a little uneven with align-items: center. When another option is added or one is deleted it will line up again.
![who-to-follow-options](https://user-images.githubusercontent.com/37485853/109091125-0e93bf80-76c9-11eb-9b5c-56be3500b45a.png)

Did not touch Firefox/Safari.

I did not adjust Chrome and Firefox Preferences section of the Readme. Perhaps you can do that after Firefox support is added.

Please let me know if you have any feedback and I'll happily fix.