### PR TITLE
Fix noTweetButton and showMessageDrawer options

### DIFF
--- a/chrome/applyOptions.js
+++ b/chrome/applyOptions.js
@@ -86,7 +86,7 @@ chrome.storage.sync.get(
 
     if (items.noTweetButton === true) {
       addStyles(`
-      a[aria-label="Tweet"][role="button"] {
+      a[aria-label="Tweet"][role="link"] {
         display: none !important;
       }
       `);
@@ -95,7 +95,7 @@ chrome.storage.sync.get(
     if (items.showMessageDrawer === true) {
       addStyles(`
       div[data-testid="DMDrawer"] {
-        visibility: hidden !important;
+        visibility: visible !important;
       }
       `);
     }

--- a/firefox/applyOptions.js
+++ b/firefox/applyOptions.js
@@ -86,7 +86,7 @@ chrome.storage.sync.get(
 
     if (items.noTweetButton === true) {
       addStyles(`
-      a[aria-label="Tweet"][role="button"] {
+      a[aria-label="Tweet"][role="link"] {
         display: none !important;
       }
       `);
@@ -95,7 +95,7 @@ chrome.storage.sync.get(
     if (items.showMessageDrawer === true) {
       addStyles(`
       div[data-testid="DMDrawer"] {
-        visibility: hidden !important;
+        visibility: visible !important;
       }
       `);
     }


### PR DESCRIPTION
This pull request updates css code writen in applyOptions.js file to make the remove tweet button and the show message drawer options work again in chrome or firefox.