### PR TITLE
Improve tweet text extraction logic for Typefully

### DIFF
--- a/extension/content/main.js
+++ b/extension/content/main.js
@@ -73,6 +73,7 @@ const addTypefullyPlug = () => {
     typefullyLink.addEventListener("click", () => {
       let tweetTextAreaNumber = 0;
       let typefullyContent = "";
+      
       while (true) {
         if (
           document.querySelector(
@@ -82,16 +83,39 @@ const addTypefullyPlug = () => {
           if (tweetTextAreaNumber > 0) {
             typefullyContent = `${typefullyContent}\n\n\n\n\n`;
           }
-          document
-            .querySelectorAll(
+          
+          let tweetTextItems = Array.from(
+            document.querySelectorAll(
               `[data-testid="tweetTextarea_${tweetTextAreaNumber}"] [data-text="true"]`
             )
-            .forEach((item) => {
+          );
+
+          // remove trailing newlines at end of tweets (there is always one last <br> on the first tweet DOM node)
+          tweetTextItems = tweetTextItems.filter((item, index) => !(item.tagName === "BR" && index === tweetTextItems.length-1));
+          
+          tweetTextItems.forEach((item, index) => {
               typefullyContent = `${typefullyContent}${item.innerText}`;
-            });
+              const isLastItem = index === tweetTextItems.length - 1;
+              const isTagOrMention = item => !!item.parentElement.parentElement.attributes.style;
+              
+              // handle hard break (2 newlines) within single tweet
+              if (item.tagName === "BR" && !isLastItem) {
+                typefullyContent += "\n\n";
+              } 
+              // handle regular text (<span> elements)
+              else {
+                typefullyContent = `${typefullyContent}${item.innerText}`;
+                
+                // this handles non-hard breaks (just one newline) within a single tweet
+                if (!isLastItem && !isTagOrMention(tweetTextItems[index+1])) {
+                  typefullyContent += "\n"
+                }
+              }
+          });
         } else {
           break;
         }
+        
         tweetTextAreaNumber = tweetTextAreaNumber + 1;
       }
 

--- a/extension/content/main.js
+++ b/extension/content/main.js
@@ -94,7 +94,6 @@ const addTypefullyPlug = () => {
           tweetTextItems = tweetTextItems.filter((item, index) => !(item.tagName === "BR" && index === tweetTextItems.length-1));
           
           tweetTextItems.forEach((item, index) => {
-              typefullyContent = `${typefullyContent}${item.innerText}`;
               const isLastItem = index === tweetTextItems.length - 1;
               const isTagOrMention = item => !!item.parentElement.parentElement.attributes.style;
               


### PR DESCRIPTION
This fixes a few issues, that are evident if you compose a tweet like this (newlines and mentions are not handled correctly):

<img width="641" alt="CleanShot 2022-02-15 at 10 11 59@2x" src="https://user-images.githubusercontent.com/715405/154030189-ead86c59-aa1f-4e0c-a644-e09561f7d884.png">

Here's a video that better explains the issue: 

https://user-images.githubusercontent.com/715405/154030128-00afdf68-735f-4744-b30d-413abce9476c.mp4


