### PR TITLE
Fix follower count still showing when option in remove distracting elements is checked

### DIFF
--- a/content-scripts/src/modules/options/hideVanityCounts.js
+++ b/content-scripts/src/modules/options/hideVanityCounts.js
@@ -66,7 +66,7 @@ export const changeFollowCount = (followCount) => {
       addStyles(
         "followCount",
         `[href$="/following"][dir][role="link"],
-        [href$="/followers"][dir][role="link"] {
+        [href*="followers"][dir][role="link"] {
           display: none;
         }`
       );


### PR DESCRIPTION
Current css selector in hideVanityCounts doesn't account for links to "/verified_followers" so making it flexible to match both "/followers" and "/verified_followers"