### PR TITLE
In zen mode overflowing content should be scrollable

### DIFF
--- a/content-scripts/src/modules/options/writerMode.js
+++ b/content-scripts/src/modules/options/writerMode.js
@@ -36,7 +36,6 @@ export const changeWriterMode = (writerMode) => {
           `
             body {
               padding-left: 0;
-              overflow: hidden;
             }
             ${selectors.mainColumn} {
               border-style: hidden;


### PR DESCRIPTION
### TL;DR

Changed the body overflow property from `hidden` to `scroll` in writer mode.

### What changed?

Modified the CSS in the `changeWriterMode` function to set the body's overflow property to `scroll` instead of `hidden`.

### How to test?

1. Enable writer mode in the application
2. Verify that content can now be scrolled when it exceeds the viewport height
3. Check that the scrolling behavior works correctly across different content lengths

### Why make this change?

The previous `overflow: hidden` setting prevented users from scrolling through content that exceeded the viewport height in writer mode. This change ensures users can access all content while maintaining the clean writer mode interface.

Fix MIN-31 and https://github.com/typefully/minimal-twitter/issues/169

[CleanShot 2025-04-16 at 22.34.55.mp4 <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/XLCshj12FUjKXyCRCqoU/5fe0f1a6-0314-4d97-9ead-c42cdb061897.mp4" />](https://app.graphite.dev/media/video/XLCshj12FUjKXyCRCqoU/5fe0f1a6-0314-4d97-9ead-c42cdb061897.mp4)

